### PR TITLE
Fix Matrix.v for coq-8.11.0

### DIFF
--- a/Matrix.v
+++ b/Matrix.v
@@ -1358,7 +1358,6 @@ Proof.
         destruct m.
         lia.
         apply Nat.div_small_iff; try lia.
-        simpl. apply Nat.neq_succ_0. 
         apply Nat.div_small in L1.
         rewrite Nat.div_div in L1; try lia.
         rewrite mult_comm.


### PR DESCRIPTION
ref: #5 

To build SQIR in coq-8.11.0, I modified lemma `id_kron` in `Matrix.v`.

I removed L1361, and now I can compile `Matrix.v` with coq-8.11.0.

By the way, I got an error in compiling of `Composition.v`, but SQIR does not depends on this file. So I leave it.