### PR TITLE
Fix a bug in QASM.v

### DIFF
--- a/QASM.v
+++ b/QASM.v
@@ -1,5 +1,10 @@
 Require Import Reals.
 Require Import String.
+Require Import HOASCircuits.
+Require Import HOASExamples.
+Require Import DBCircuits.
+Require Import Arith.
+Require Import List.
 
 (* QASM.v - representation of QASM circuits *)
 
@@ -104,12 +109,6 @@ Open Scope qasm_scope.
 Notation pi := (e_pi).
 Close Scope qasm_scope.
 
-Require Import HOASCircuits.
-Require Import HOASExamples.
-Require Import DBCircuits.
-Require Import Arith.
-Require Import Reals.
-Require Import List.
 
 Open Scope R_scope.
 Import ListNotations.


### PR DESCRIPTION
When I run `make qasm` with Coq 8.13.1, the `id : R -> R` imported by `Require Import Reals.` overrides `Definition id := string.` and causes a compile error.
So I move all relevant import statements to the top.