### PR TITLE
fixed errors for 8.14 & warnings for 8.13; broke things for <8.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ extra/*
 .coqdeps.d
 CoqMakefile
 CoqMakefile.conf
+
+.CoqMakefile.d
+.nia.cache
+.nra.cache

--- a/Ancilla.v
+++ b/Ancilla.v
@@ -68,12 +68,13 @@ Proof.
       destruct Γ1 as [|Γ1]; try invalid_contradiction.
       erewrite denote_compose with (Γ1:=[]); trivial.        
       Locate ":Fun".
-      Focus 3.
+      3:{
         intros Γ3 Γ0' p0 H0 H1.
         destruct H0.
         rewrite merge_nil_r in pf_merge.
         subst.
         apply (t0 Γ3); trivial.
+        all: admit. }
         
 (*        
       rewrite denote_compose with (Γ1:=Γ); trivial.        

--- a/Arithmetic.v
+++ b/Arithmetic.v
@@ -202,13 +202,13 @@ Lemma calc_id_circ_with_pads_WT : forall n,
   Typed_Box (calc_id_circ_with_pads n).
 Proof. intros. apply compile_WT. Qed.
 
-Hint Resolve adder_cout_circ_WT adder_sum_circ_WT adder_cout_circ_with_pads_WT adder_sum_circ_with_pads_WT calc_xor_circ_WT calc_id_circ_WT calc_id_circ_with_pads_WT : typed_db.
+#[export] Hint Resolve adder_cout_circ_WT adder_sum_circ_WT adder_cout_circ_with_pads_WT adder_sum_circ_with_pads_WT calc_xor_circ_WT calc_id_circ_WT calc_id_circ_with_pads_WT : typed_db.
 
-Hint Extern 2 (Typed_Box (adder_cout_circ_with_pads _)) => 
+#[export] Hint Extern 2 (Typed_Box (adder_cout_circ_with_pads _)) => 
   apply adder_cout_circ_with_pads_WT : typed_db.
-Hint Extern 2 (Typed_Box (adder_sum_circ_with_pads _)) => 
+#[export] Hint Extern 2 (Typed_Box (adder_sum_circ_with_pads _)) => 
   apply adder_sum_circ_with_pads_WT : typed_db.
-Hint Extern 2 (Typed_Box (calc_id_circ_with_pads _)) =>
+#[export] Hint Extern 2 (Typed_Box (calc_id_circ_with_pads _)) =>
   apply calc_id_circ_with_pads_WT : typed_db.
 
 Open Scope matrix_scope.
@@ -358,12 +358,12 @@ Proof.
   - apply adder_cout_circ_with_pads_WT.
 Qed.
 
-Hint Resolve carrier_circ_1_WT carrier_circ_1_with_pads_WT adder_circ_1_WT 
+#[export] Hint Resolve carrier_circ_1_WT carrier_circ_1_with_pads_WT adder_circ_1_WT 
      adder_circ_1_with_pads_WT : typed_db.
 
-Hint Extern 2 (Typed_Box (carrier_circ_1_with_pads _)) =>
+#[export] Hint Extern 2 (Typed_Box (carrier_circ_1_with_pads _)) =>
   apply carrier_circ_1_with_pads_WT : typed_db.
-Hint Extern 2 (Typed_Box (adder_circ_1_with_pads _)) =>
+#[export] Hint Extern 2 (Typed_Box (adder_circ_1_with_pads _)) =>
   apply adder_circ_1_with_pads_WT : typed_db.
 
 Open Scope matrix_scope.

--- a/Contexts.v
+++ b/Contexts.v
@@ -463,8 +463,8 @@ Instance PCM_Laws_OCtx : PCM_Laws OCtx :=
   ; M_absorb := merge_I_r
   }.
 
-Hint Resolve PCM_OCtx : core.
-Hint Resolve PCM_Laws_OCtx : core.
+#[export] Hint Resolve PCM_OCtx : core.
+#[export] Hint Resolve PCM_Laws_OCtx : core.
 
 (*** Validity ***)
 

--- a/Denotation.v
+++ b/Denotation.v
@@ -51,7 +51,7 @@ Lemma WF_Matrix_U : forall {W} (U : Unitary W),
 Proof.
   induction U; simpl; try apply WF_control; auto with wf_db. (* try shouldn't be necessary *)
 Qed.
-Hint Resolve WF_Matrix_U : wf_db.
+#[export] Hint Resolve WF_Matrix_U : wf_db.
 Lemma unitary_gate_unitary : forall {W} (U : Unitary W), WF_Unitary (⟦U⟧).
 Proof.
   induction U.
@@ -132,7 +132,7 @@ Proof.
   specialize (WF_Matrix_U u). intros wf_u. auto with wf_db.
   specialize (WF_Matrix_U u). intros wf_u. auto with wf_db.
 Qed.
-Hint Resolve WF_denote_gate : wf_db.
+#[export] Hint Resolve WF_denote_gate : wf_db.
 
 Close Scope circ_scope.
 
@@ -4187,7 +4187,7 @@ Definition HOAS_Equiv {W1 W2} (c1 c2 : Box W1 W2) :=
 Locate "≡".
 Notation "a ≡ b" := (HOAS_Equiv a b) (at level 70) : circ_scope.
 
-Hint Unfold HOAS_Equiv : den_db.
+#[export] Hint Unfold HOAS_Equiv : den_db.
     
 Open Scope circ_scope.
 
@@ -4260,14 +4260,14 @@ Add Parametric Relation W1 W2 : (Box W1 W2) (@HOAS_Equiv W1 W2)
 (************************)
 
 (* add_fresh *)
-Hint Unfold get_fresh add_fresh_state add_fresh_pat process_gate process_gate_state : den_db.
+#[export] Hint Unfold get_fresh add_fresh_state add_fresh_pat process_gate process_gate_state : den_db.
 
-Hint Unfold apply_new0 apply_new1 apply_U apply_unitary denote_ctrls apply_meas apply_discard apply_assert0 apply_assert1 compose_super Splus swap_list swap_two pad denote_box denote_pat super: den_db.
+#[export] Hint Unfold apply_new0 apply_new1 apply_U apply_unitary denote_ctrls apply_meas apply_discard apply_assert0 apply_assert1 compose_super Splus swap_list swap_two pad denote_box denote_pat super: den_db.
 
 (* add_fresh *)
-Hint Unfold get_fresh add_fresh_state add_fresh_pat process_gate process_gate_state : vector_den_db.
+#[export] Hint Unfold get_fresh add_fresh_state add_fresh_pat process_gate process_gate_state : vector_den_db.
 
-Hint Unfold apply_new0 apply_new1 apply_U apply_unitary denote_ctrls apply_meas apply_discard apply_assert0 apply_assert1 compose_super Splus swap_list swap_two pad denote_box denote_pat : vector_den_db.
+#[export] Hint Unfold apply_new0 apply_new1 apply_U apply_unitary denote_ctrls apply_meas apply_discard apply_assert0 apply_assert1 compose_super Splus swap_list swap_two pad denote_box denote_pat : vector_den_db.
 
 Ltac vector_denote :=
   intros; 

--- a/Equations.v
+++ b/Equations.v
@@ -324,7 +324,7 @@ Definition lift_new : Box Bit Bit :=
 Lemma lift_new_WT : Typed_Box lift_new.
 Proof. type_check. Qed.
 
-Hint Unfold Splus : den_db.
+#[export] Hint Unfold Splus : den_db.
 
 Definition Classical {n} (ρ : Density n) := forall i j, i <> j -> ρ i j = 0.
 

--- a/GHZ.v
+++ b/GHZ.v
@@ -81,7 +81,7 @@ Proof.
       try apply WF_qubit0; try apply WF_qubit1.
 Qed.
 
-Hint Resolve wf_ghz wf_nket wf_notc : wf_db.
+#[export] Hint Resolve wf_ghz wf_nket wf_notc : wf_db.
 
 Lemma ctrl_list_notc :
   forall n : nat, 

--- a/HOASLib.v
+++ b/HOASLib.v
@@ -205,7 +205,7 @@ Notation "g # n" := (inParMany n g) (at level 11) : circ_scope.
 
 
 
-Hint Resolve types_units id_circ_WT boxed_gate_WT init_WT inSeq_WT inPar_WT 
+#[export] Hint Resolve types_units id_circ_WT boxed_gate_WT init_WT inSeq_WT inPar_WT 
      initMany_WT inSeqMany_WT inParMany_WT : typed_db.
 
 (*********************)

--- a/HOASProofs.v
+++ b/HOASProofs.v
@@ -75,7 +75,7 @@ Proof. intros. apply unitary_gate_unitary. Qed.
 Lemma WF_trans : forall W (U : Unitary W), WF_Matrix (denote_unitary (trans U)).
 Proof. intros. apply unitary_gate_unitary. Qed.
 
-Hint Resolve WF_denote_unitary : wf_db.
+#[export] Hint Resolve WF_denote_unitary : wf_db.
 
 
 Lemma unitary_transpose_id : forall W (U : Unitary W),
@@ -190,8 +190,8 @@ Proof.
   intros; show_wf.
 Qed.
 
-Hint Resolve wf_biased_coin : wf_db.
-Hint Unfold super_Zero : den_db. 
+#[export] Hint Resolve wf_biased_coin : wf_db.
+#[export] Hint Unfold super_Zero : den_db. 
 
 (* Uses denote_compose: *)
 (*
@@ -330,7 +330,7 @@ Proof.
 Abort.
 *)
   
-Hint Unfold apply_box : den_db.
+#[export] Hint Unfold apply_box : den_db.
 
 Open Scope matrix_scope.
 
@@ -340,7 +340,7 @@ Definition prepare (ls : list nat) : Vector (2^(length ls)) :=
   fold_left (fun A x => ket x ⊗ A) ls ((I 1)).
 *)
 
-Fixpoint prepare (ls : list nat) : Vector (2^(length ls)) :=
+Definition prepare (ls : list nat) : Vector (2^(length ls)) :=
   ⨂ (map ket ls).
 
 Definition pure {n} (vec : Matrix n 1%nat) : Matrix n n := vec × (vec †).
@@ -352,7 +352,7 @@ Proof.
   show_wf.
 Qed.
 
-Hint Unfold pure : den_db.
+#[export] Hint Unfold pure : den_db.
 Close Scope matrix_scope.
 
 (*
@@ -441,7 +441,7 @@ Definition U_balanced (U : Unitary (Qubit ⊗ Qubit)%qc) :=
   apply_U 2 U [0;1]%nat = super f1 \/ apply_unitary 2 U [0;1]%nat = f2.
 
 Lemma f2_WF : WF_Matrix f2. Proof. show_wf. Qed.
-Hint Resolve f2_WF : wf_db.
+#[export] Hint Resolve f2_WF : wf_db.
 
 Close Scope matrix_scope.
 Open Scope circ_scope.  

--- a/Matrix.v
+++ b/Matrix.v
@@ -237,7 +237,7 @@ Notation "Σ^ n f" := (Csum f n) (at level 60) : matrix_scope.
 Notation "n ⨂ A" := (kron_n n A) (at level 30, no associativity) : matrix_scope.
 Notation "⨂ A" := (big_kron A) (at level 60): matrix_scope.
 Notation "n ⨉ A" := (Mmult_n n A) (at level 30, no associativity) : matrix_scope.
-Hint Unfold Zero I trace dot Mplus scale Mmult kron mat_equiv transpose 
+#[export] Hint Unfold Zero I trace dot Mplus scale Mmult kron mat_equiv transpose 
             adjoint : U_db.
   
 Ltac destruct_m_1 :=
@@ -681,10 +681,10 @@ Ltac show_wf :=
   try lca.
 
 (* Create HintDb wf_db. *)
-Hint Resolve WF_Zero WF_I WF_I1 WF_mult WF_plus WF_scale WF_transpose 
+#[export] Hint Resolve WF_Zero WF_I WF_I1 WF_mult WF_plus WF_scale WF_transpose 
      WF_adjoint WF_outer_product WF_big_kron WF_kron_n WF_kron 
      WF_Mmult_n WF_Msum : wf_db.
-Hint Extern 2 (_ = _) => unify_pows_two : wf_db.
+#[export] Hint Extern 2 (_ = _) => unify_pows_two : wf_db.
 
 (* Hint Resolve WF_Matrix_dim_change : wf_db. *)
 
@@ -1256,7 +1256,8 @@ Proof.
   intros. bdestruct (y =? 0). subst. simpl.
   bdestruct (z =? 0). subst. easy.
   apply Nat.mod_0_l. easy.
-  bdestruct (z =? 0). subst. rewrite Nat.mul_0_r. simpl. rewrite Nat.div_0_l; easy.
+  bdestruct (z =? 0). subst. rewrite Nat.mul_0_r. simpl. 
+  try rewrite Nat.div_0_l; easy.
   pattern x at 1. rewrite (Nat.div_mod x (y * z)) by nia.
   replace (y * z * (x / (y * z))) with ((z * (x / (y * z))) * y) by lia.
   rewrite Nat.div_add_l with (b := y) by easy.
@@ -1272,7 +1273,7 @@ Lemma sub_mul_mod :
     y * z <= x ->
     (x - y * z) mod z = x mod z.
 Proof.
-  intros. bdestruct (z =? 0). subst. easy.
+  intros. bdestruct (z =? 0). subst. simpl. lia.
   specialize (le_plus_minus_r (y * z) x H) as G.
   remember (x - (y * z)) as r.
   rewrite <- G. rewrite <- Nat.add_mod_idemp_l by easy. rewrite Nat.mod_mul by easy.
@@ -1281,7 +1282,8 @@ Qed.
 
 Lemma mod_product : forall x y z, y <> 0 -> x mod (y * z) mod z = x mod z.
 Proof.
-  intros x y z H. bdestruct (z =? 0). subst. easy.
+  intros x y z H. bdestruct (z =? 0). subst. 
+  simpl. try rewrite Nat.mul_0_r. reflexivity.
   pattern x at 2. rewrite Nat.mod_eq with (b := y * z) by nia.
   replace (y * z * (x / (y * z))) with (y * (x / (y * z)) * z) by lia.
   rewrite sub_mul_mod. easy.

--- a/Monad.v
+++ b/Monad.v
@@ -36,7 +36,7 @@ Class Monad (m: Type -> Type) `{M : Applicative m} : Type :=
 Definition return_ {m : Type -> Type} `{M : Monad m} {A : Type} : A -> m A := pure.
 Notation "a >>= f" := (bind a f) (at level 50, left associativity).
 
-Hint Unfold bind return_ : monad_db.
+#[export] Hint Unfold bind return_ : monad_db.
 
 Class Monad_Correct (m : Type -> Type) `{M : Monad m} := {
   bind_right_unit: forall A (a: m A), a = a >>= return_;
@@ -81,7 +81,7 @@ Fixpoint foldM {A B m} `{Monad m}
   | x :: ls' => do y ← f b x;
                 foldM f y ls'
   end.
-Hint Unfold foldM : monad_db.
+#[export] Hint Unfold foldM : monad_db.
 
 About fmap_compose.
 Lemma fmap_compose' {f} (F : Functor f) `{Functor_Correct f} : 
@@ -147,7 +147,7 @@ Definition list_fmap {A B} (f : A -> B) :=
   end.
 *)
 Definition list_fmap := map.
-Hint Unfold list_fmap : monad_db.
+#[export] Hint Unfold list_fmap : monad_db.
 (*
 Fixpoint list_fmap {A B} (f : A -> B) (ls : list A) : list B :=
   match ls with
@@ -167,14 +167,14 @@ Definition list_liftA {A B} (fs : list (A -> B)) (xs : list A) : list B :=
   let g := fun a => list_fmap (fun f => f a) fs
   in
   concat (list_fmap g xs).
-Hint Unfold list_liftA : monad_db.
+#[export] Hint Unfold list_liftA : monad_db.
 
 Fixpoint list_bind {A} (xs : list A) {B} (f : A -> list B) : list B :=
   match xs with
   | nil => nil
   | a :: xs' => f a ++ list_bind xs' f
   end.
-Hint Unfold list_bind : monad_db.
+#[export] Hint Unfold list_bind : monad_db.
 
 Instance listF : Functor list := { fmap := @list_fmap }.
 Instance listA : Applicative list := { pure := fun _ x => x :: nil
@@ -347,7 +347,7 @@ Section State.
 
 
 End State.
-Hint Unfold put get runState evalState execState state_fmap state_liftA state_bind : monad_db.
+#[export] Hint Unfold put get runState evalState execState state_fmap state_liftA state_bind : monad_db.
 Ltac fold_evalState :=
   match goal with
   | [ |- context[fst (?c ?v)] ] => replace (fst (c v)) with (evalState c v)
@@ -403,7 +403,7 @@ Instance stateM_correct {A} : Monad_Correct (State A).
       reflexivity.
   Qed.
 
-Hint Unfold Basics.compose : monad_db.
-Hint Unfold stateM : monad_db.
+#[export] Hint Unfold Basics.compose : monad_db.
+#[export] Hint Unfold stateM : monad_db.
 
 

--- a/Monoid.v
+++ b/Monoid.v
@@ -23,7 +23,7 @@ Class PCM_Laws A `{PCM A} :=
   ; M_absorb : forall a, a ∘ ⊥ = ⊥ 
   }.
 
-Hint Resolve M_unit M_assoc M_comm M_absorb : core.
+#[export] Hint Resolve M_unit M_assoc M_comm M_absorb : core.
 
 (****************************)
 (* Interpretable type class *)

--- a/Oracles.v
+++ b/Oracles.v
@@ -13,8 +13,6 @@ Require Import List.
 Set Bullet Behavior "Strict Subproofs".
 Global Unset Asymmetric Patterns.
 
-Require Import Omega.
-
 (* --------------------------------*)
 (* Reversible bexps with variables *)
 (* --------------------------------*)
@@ -642,7 +640,7 @@ Ltac compile_typing lem :=
 Lemma compile_WT : forall (b : bexp) (Γ : Ctx), Typed_Box (compile b Γ).
 Proof. induction b; intros; simpl; compile_typing True. Qed.
 
-Hint Resolve compile_WT : typed_db.
+#[export] Hint Resolve compile_WT : typed_db.
 
 Open Scope matrix_scope.
 
@@ -681,7 +679,7 @@ Qed.
 Lemma WF_ctx_to_mat_list : forall Γ f, @WF_Matrix (2^⟦Γ⟧) (2^⟦Γ⟧) (big_kron (ctx_to_mat_list Γ f)).
 Proof. apply WF_ctx_to_matrix. Qed.
 
-Hint Resolve WF_ctx_to_matrix WF_ctx_to_mat_list : wf_db.
+#[export] Hint Resolve WF_ctx_to_matrix WF_ctx_to_mat_list : wf_db.
 
 Lemma pure_bool_to_matrix : forall b, Pure_State (bool_to_matrix b).
 Proof. destruct b. apply pure1. apply pure0. Qed.
@@ -823,7 +821,7 @@ Ltac rewrite_inPar :=
   end; (restore_dims tensor_dims); eauto with wf_db; try solve [type_check]. 
 
 (* For ctx_to_matrix, ctx_to_mat_list proofs *)
-Hint Extern 2 (WF_Matrix _) => rewrite size_ntensor, Nat.mul_1_r : wf_db.          
+#[export] Hint Extern 2 (WF_Matrix _) => rewrite size_ntensor, Nat.mul_1_r : wf_db.          
 
 (*
 Hint Extern 2 (WF_Matrix (⨂ ctx_to_mat_list _ _)) =>
@@ -1018,9 +1016,9 @@ Fact Toffoli_at_spec : forall (b1 b2 b3 : bool) (n x y z : nat) (li : list (Matr
  ⟦Toffoli_at n x y z⟧ (⨂ li) = ⨂ (update_at li z (bool_to_matrix ((b1 && b2) ⊕ b3))).
 Admitted.
 
-Hint Extern 2 (WF_Matrix _) => rewrite ctx_to_mat_list_length : wf_db.
-Hint Resolve WF_denote_box : wf_db.    
-Hint Extern 2 (Typed_Box _) => type_check : wf_db.
+#[export] Hint Extern 2 (WF_Matrix _) => rewrite ctx_to_mat_list_length : wf_db.
+#[export] Hint Resolve WF_denote_box : wf_db.    
+#[export] Hint Extern 2 (Typed_Box _) => type_check : wf_db.
 
 Lemma init_at_spec : forall (b : bool) (n i : nat) (l1 l2 : list (Square 2)) (A B : Square 2), 
   length l1 = i ->

--- a/Prelim.v
+++ b/Prelim.v
@@ -41,7 +41,7 @@ Proof.
   apply iff_reflect. symmetry. apply Nat.leb_le.
 Qed.
 
-Hint Resolve blt_reflect ble_reflect beq_reflect : bdestruct.
+#[export] Hint Resolve blt_reflect ble_reflect beq_reflect : bdestruct.
 
 Ltac bdestruct X :=
   let H := fresh in let e := fresh "e" in

--- a/Quantum.v
+++ b/Quantum.v
@@ -197,7 +197,7 @@ Definition swap : Matrix (2*2) (2*2) :=
           | _, _ => C0
           end.
 
-Hint Unfold qubit0 qubit1 hadamard σx σy σz control cnot swap bra ket : U_db.
+#[export] Hint Unfold qubit0 qubit1 hadamard σx σy σz control cnot swap bra ket : U_db.
 
 (** ** Rotation Matrices *)
                               
@@ -580,9 +580,9 @@ Proof.
   apply IHl.
 Qed.
 
-Hint Resolve WF_bra0 WF_bra1 WF_qubit0 WF_qubit1 WF_braqubit0 WF_braqubit1 : wf_db.
-Hint Resolve WF_bool_to_ket WF_bool_to_matrix WF_bool_to_matrix' : wf_db.
-Hint Resolve WF_ket WF_bra WF_bools_to_matrix : wf_db.
+#[export] Hint Resolve WF_bra0 WF_bra1 WF_qubit0 WF_qubit1 WF_braqubit0 WF_braqubit1 : wf_db.
+#[export] Hint Resolve WF_bool_to_ket WF_bool_to_matrix WF_bool_to_matrix' : wf_db.
+#[export] Hint Resolve WF_ket WF_bra WF_bools_to_matrix : wf_db.
 
 Lemma WF_hadamard : WF_Matrix hadamard. Proof. show_wf. Qed.
 Lemma WF_σx : WF_Matrix σx. Proof. show_wf. Qed.
@@ -606,11 +606,11 @@ Proof.
   all: rewrite WFU; [reflexivity|lia].
 Qed.
 
-Hint Resolve WF_hadamard WF_σx WF_σy WF_σz WF_cnot WF_swap WF_phase : wf_db.
-Hint Resolve WF_rotation : wf_db.
+#[export] Hint Resolve WF_hadamard WF_σx WF_σy WF_σz WF_cnot WF_swap WF_phase : wf_db.
+#[export] Hint Resolve WF_rotation : wf_db.
 
-Hint Extern 2 (WF_Matrix (phase_shift _)) => apply WF_phase : wf_db.
-Hint Extern 2 (WF_Matrix (control _)) => apply WF_control : wf_db.
+#[export] Hint Extern 2 (WF_Matrix (phase_shift _)) => apply WF_phase : wf_db.
+#[export] Hint Extern 2 (WF_Matrix (control _)) => apply WF_control : wf_db.
 
 (***************************)
 (** Unitaries are unitary **)
@@ -622,7 +622,7 @@ Hint Extern 2 (WF_Matrix (control _)) => apply WF_control : wf_db.
 Definition WF_Unitary {n: nat} (U : Matrix n n): Prop :=
   WF_Matrix U /\ U † × U = I n.
 
-Hint Unfold WF_Unitary : U_db.
+#[export] Hint Unfold WF_Unitary : U_db.
 
 (* More precise *)
 (* Definition unitary_matrix' {n: nat} (A : Matrix n n): Prop := Minv A A†. *)
@@ -1226,11 +1226,11 @@ Inductive Mixed_State {n} : Matrix n n -> Prop :=
 
 Lemma WF_Pure : forall {n} (ρ : Density n), Pure_State ρ -> WF_Matrix ρ.
 Proof. intros. destruct H as [φ [[WFφ IP1] Eρ]]. rewrite Eρ. auto with wf_db. Qed.
-Hint Resolve WF_Pure : wf_db.
+#[export] Hint Resolve WF_Pure : wf_db.
 
 Lemma WF_Mixed : forall {n} (ρ : Density n), Mixed_State ρ -> WF_Matrix ρ.
 Proof. induction 1; auto with wf_db. Qed.
-Hint Resolve WF_Mixed : wf_db.
+#[export] Hint Resolve WF_Mixed : wf_db.
 
 Lemma pure0 : Pure_State ∣0⟩⟨0∣. 
 Proof. exists ∣0⟩. intuition. split. auto with wf_db. solve_matrix. Qed.
@@ -1457,7 +1457,7 @@ Proof.
   auto with wf_db.
 Qed.
 
-Hint Resolve WF_super : wf_db.
+#[export] Hint Resolve WF_super : wf_db.
 
 Lemma super_outer_product : forall m (φ : Matrix m 1) (U : Matrix m m), 
     super U (outer_product φ φ) = outer_product (U × φ) (U × φ).
@@ -1481,7 +1481,7 @@ Proof.
   auto.
 Qed.
 
-Hint Resolve WF_compose_super : wf_db.
+#[export] Hint Resolve WF_compose_super : wf_db.
 
 
 Lemma compose_super_correct : forall {m n p} 

--- a/Symmetric.v
+++ b/Symmetric.v
@@ -14,8 +14,6 @@ Set Bullet Behavior "Strict Subproofs".
 Global Unset Asymmetric Patterns.
 Delimit Scope matrix_scope with M.
 
-Require Import Omega.
-
 (**********************)
 (* Syntactic Property *)
 (**********************)
@@ -23,8 +21,6 @@ Require Import Omega.
 Close Scope matrix_scope.
 Open Scope circ_scope.
 Open Scope nat_scope.
-
-Require Import Omega.
 
 Definition unitary_at1 n (U : Unitary Qubit) (i : Var) (pf : i < n)
         : Box (n ⨂ Qubit) (n ⨂ Qubit).
@@ -796,7 +792,7 @@ Defined.
 
 (* Symmetric gates are well-typed *)
 
-Hint Resolve unitary_at1_WT X_at_WT CNOT_at_WT Toffoli_at_WT init_at_WT assert_at_WT : typed_db.
+#[export] Hint Resolve unitary_at1_WT X_at_WT CNOT_at_WT Toffoli_at_WT init_at_WT assert_at_WT : typed_db.
 
 Lemma gate_acts_on_WT : forall m (g : Box (m ⨂ Qubit) (m ⨂ Qubit)) k, 
                         gate_acts_on k g -> Typed_Box g.


### PR DESCRIPTION
This PR fixes a couple minor issues that were preventing `make all` from succeeding with Coq v8.14. I also made a few edits to reduce warnings in v8.13 (which involved adding `#[export]` in front of Hints). There are still warnings when compiling with 8.14 (which can be fixed using the same approach), but this breaks things for v8.13.

Which versions of Coq do you want to "support"? The README says 8.10-8.12. The current code will compile for 8.12, 8.13, 8.14. While testing, I found out that I broke things for versions < 8.12 with my call to `Rtrigo_facts.cos_pi_minus` in [this commit](https://github.com/inQWIRE/QWIRE/commit/7a99a53f93160d945fd8e83d768bbe4197cebc26#diff-ef73c335f0092d006bb16e6d8be02850897b9aca1c25bb0a95030cd0f5da9778) (sorry!!). Do you want me to remove this from the repo so you're still compatible with versions 8.10 and 8.11? 

If you don't want to support 8.13/8.14, then you can reject this PR. Just let me know what you decide because it impacts which versions I'll support for [SQIR](https://github.com/inQWIRE/SQIR) :)